### PR TITLE
Update to Elixir 1.15.0-rc.0.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 26.0
-elixir 1.14.4-otp-26
+elixir 1.15.0-rc.0-otp-26

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.14.2-erlang-25.1.2-debian-bullseye-20221004-slim
 #
-ARG ELIXIR_VERSION=1.14.4
+ARG ELIXIR_VERSION=1.15.0-rc.0
 ARG OTP_VERSION=26.0
 ARG DEBIAN_VERSION=bullseye-20230227-slim
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rng.MixProject do
     [
       app: :rng,
       version: "0.1.0",
-      elixir: "~> 1.14.4",
+      elixir: "~> 1.15.0-rc.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
This PR supports the following features:

- update to Elixir 1.15.0-rc.0