### PR TITLE
Downgrade to Erlang 25.3.2.2.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.0.1
-elixir 1.15.0-rc.1-otp-26
+erlang 25.3.2.2
+elixir 1.15.0-rc.1-otp-25


### PR DESCRIPTION
This PR supports the following features:

- downgrade to Erlang 25.3.2.2